### PR TITLE
Implemented the "effective epsilon" trick.

### DIFF
--- a/relm/mechanisms.py
+++ b/relm/mechanisms.py
@@ -60,9 +60,12 @@ class LaplaceMechanism(ReleaseMechanism):
     """
 
     def __init__(self, epsilon, sensitivity, precision):
+        super(LaplaceMechanism, self).__init__(epsilon)
         self.sensitivity = sensitivity
         self.precision = precision
-        super(LaplaceMechanism, self).__init__(epsilon)
+        self.effective_epsilon = self.epsilon / (
+            self.sensitivity + 2.0 ** -self.precision
+        )
 
     def release(self, values):
         """
@@ -78,7 +81,7 @@ class LaplaceMechanism(ReleaseMechanism):
         self._check_valid()
         self._is_valid = False
         self._update_accountant()
-        args = (values, self.sensitivity, self.epsilon, self.precision)
+        args = (values, self.effective_epsilon, self.precision)
         return backend.laplace_mechanism(*args)
 
     @property
@@ -92,7 +95,7 @@ class LaplaceMechanism(ReleaseMechanism):
             return self.epsilon
 
 
-class GeometricMechanism(LaplaceMechanism):
+class GeometricMechanism(ReleaseMechanism):
     """
     Secure implementation of the Geometric mechanism. This mechanism can be used once
     after which its privacy budget will be exhausted and it can no longer be used.
@@ -103,7 +106,9 @@ class GeometricMechanism(LaplaceMechanism):
     """
 
     def __init__(self, epsilon, sensitivity):
-        super(GeometricMechanism, self).__init__(epsilon, sensitivity, precision=0)
+        super(GeometricMechanism, self).__init__(epsilon)
+        self.sensitivity = sensitivity
+        self.effective_epsilon = self.epsilon / self.sensitivity
 
     def release(self, values):
         """
@@ -118,7 +123,17 @@ class GeometricMechanism(LaplaceMechanism):
         self._check_valid()
         self._is_valid = False
         self._update_accountant()
-        return backend.geometric_mechanism(values, self.sensitivity, self.epsilon)
+        return backend.geometric_mechanism(values, self.effective_epsilon)
+
+    @property
+    def privacy_consumed(self):
+        """
+        Computes the privacy budget consumed by the mechanism so far.
+        """
+        if self._is_valid:
+            return 0
+        else:
+            return self.epsilon
 
 
 class ExponentialMechanism(ReleaseMechanism):
@@ -151,6 +166,8 @@ class ExponentialMechanism(ReleaseMechanism):
         self.sensitivity = sensitivity
         self.output_range = output_range
         self.method = method
+
+        self.effective_epsilon = self.epsilon / (2.0 * sensitivity)
 
     def release(self, values):
         """
@@ -189,15 +206,15 @@ class ExponentialMechanism(ReleaseMechanism):
     def method(self, value):
         if value == "weighted_index":
             sampler = lambda utilities: backend.exponential_mechanism_weighted_index(
-                utilities, self.sensitivity, self.epsilon
+                utilities, self.effective_epsilon
             )
         elif value == "gumbel_trick":
             sampler = lambda utilities: backend.exponential_mechanism_gumbel_trick(
-                utilities, self.sensitivity, self.epsilon
+                utilities, self.effective_epsilon
             )
         elif value == "sample_and_flip":
             sampler = lambda utilities: backend.exponential_mechanism_sample_and_flip(
-                utilities, self.sensitivity, self.epsilon
+                utilities, self.effective_epsilon
             )
         else:
             raise ValueError("Sampling method '%s' not supported." % method)
@@ -232,6 +249,8 @@ class PermuteAndFlipMechanism(ReleaseMechanism):
         self.sensitivity = sensitivity
         self.output_range = output_range
 
+        self.effective_epsilon = self.epsilon / (2.0 * sensitivity)
+
     def release(self, values):
         """
         Releases a differential private query response.
@@ -248,9 +267,7 @@ class PermuteAndFlipMechanism(ReleaseMechanism):
         self._update_accountant()
 
         utilities = self.utility_function(values)
-        index = backend.permute_and_flip_mechanism(
-            utilities, self.sensitivity, self.epsilon
-        )
+        index = backend.permute_and_flip_mechanism(utilities, self.effective_epsilon)
         return self.output_range[index]
 
     @property
@@ -277,7 +294,8 @@ class SparseGeneric(ReleaseMechanism):
         precision=35,
     ):
         epsilon = epsilon1 + epsilon2 + epsilon3
-        self.epsilon = epsilon
+        super(SparseGeneric, self).__init__(epsilon)
+
         self.epsilon1 = epsilon1
         self.epsilon2 = epsilon2
         self.epsilon3 = epsilon3
@@ -288,18 +306,19 @@ class SparseGeneric(ReleaseMechanism):
         self.precision = precision
         self.current_count = 0
 
-        temp = np.array([threshold], dtype=np.float64)
-        args = (temp, sensitivity, epsilon1, precision)
+        self.effective_epsilon1 = self.epsilon1 / self.sensitivity
+        self.effective_epsilon2 = self.epsilon2 / (self.cutoff * self.sensitivity)
+        if not self.monotonic:
+            self.effective_epsilon2 /= 2.0
+        self.effective_epsilon3 = self.epsilon3 / (self.cutoff * self.sensitivity)
+
+        temp = np.array([self.threshold], dtype=np.float64)
+        args = (temp, self.effective_epsilon1, self.precision)
         self.perturbed_threshold = backend.laplace_mechanism(*args)[0]
-        super(SparseGeneric, self).__init__(epsilon)
 
     def all_above_threshold(self, values):
-        if self.monotonic:
-            b = (self.sensitivity * self.cutoff) / self.epsilon2
-        else:
-            b = (2.0 * self.sensitivity * self.cutoff) / self.epsilon2
         return backend.all_above_threshold(
-            values, b, self.perturbed_threshold, self.precision
+            values, self.effective_epsilon2, self.perturbed_threshold, self.precision
         )
 
     def release(self, values):
@@ -326,8 +345,11 @@ class SparseGeneric(ReleaseMechanism):
 
         if self.epsilon3 > 0:
             sliced_values = values[indices]
-            temp = self.sensitivity * self.cutoff
-            args = (sliced_values, temp, self.epsilon3, self.precision)
+            args = (
+                sliced_values,
+                self.effective_epsilon3,
+                self.precision,
+            )
             release_values = backend.laplace_mechanism(*args)
             return indices, release_values
         else:
@@ -565,9 +587,10 @@ class ReportNoisyMax(ReleaseMechanism):
     """
 
     def __init__(self, epsilon, precision):
+        super(ReportNoisyMax, self).__init__(epsilon)
         self.sensitivity = 1.0
         self.precision = precision
-        super(ReportNoisyMax, self).__init__(epsilon)
+        self.effective_epsilon = self.epsilon / self.sensitivity
 
     def release(self, values):
         """
@@ -582,7 +605,7 @@ class ReportNoisyMax(ReleaseMechanism):
         self._check_valid()
         self._is_valid = False
         self._update_accountant()
-        args = (values, self.sensitivity, self.epsilon, self.precision)
+        args = (values, self.effective_epsilon, self.precision)
         perturbed_values = backend.laplace_mechanism(*args)
         valmax = np.max(perturbed_values)
         argmax = secrets.choice(np.where(perturbed_values == valmax)[0])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@ fn backend(_py: Python, m: &PyModule) -> PyResult<()> {
     fn py_all_above_threshold<'a>(
         py: Python<'a>,
         data: &'a PyArray1<f64>,
-        scale: f64,
+        epsilon: f64,
         threshold: f64,
         precision: i32,
     ) -> &'a PyArray1<usize> {
         /// Simple python wrapper of the exponential function. Converts
         /// the rust vector into a numpy array
         let data = data.to_vec().unwrap();
-        mechanisms::all_above_threshold(data, scale, threshold, precision).to_pyarray(py)
+        mechanisms::all_above_threshold(data, epsilon, threshold, precision).to_pyarray(py)
     }
 
     #[pyfn(m, "snapping")]
@@ -46,23 +46,21 @@ fn backend(_py: Python, m: &PyModule) -> PyResult<()> {
     fn py_laplace_mechanism<'a>(
         py: Python<'a>,
         data: &'a PyArray1<f64>,
-        sensitivity: f64,
         epsilon: f64,
         precision: i32,
     ) -> &'a PyArray1<f64> {
         let data = data.to_vec().unwrap();
-        mechanisms::laplace_mechanism(data, sensitivity, epsilon, precision).to_pyarray(py)
+        mechanisms::laplace_mechanism(data, epsilon, precision).to_pyarray(py)
     }
 
     #[pyfn(m, "geometric_mechanism")]
     fn py_geometric_mechanism<'a>(
         py: Python<'a>,
         data: &'a PyArray1<i64>,
-        sensitivity: f64,
         epsilon: f64,
     ) -> &'a PyArray1<i64> {
         let data = data.to_vec().unwrap();
-        mechanisms::geometric_mechanism(data, sensitivity, epsilon).to_pyarray(py)
+        mechanisms::geometric_mechanism(data, epsilon).to_pyarray(py)
     }
 
 
@@ -70,13 +68,11 @@ fn backend(_py: Python, m: &PyModule) -> PyResult<()> {
     fn py_exponential_mechanism_weighted_index<'a>(
         py: Python<'a>,
         utilities: &'a PyArray1<f64>,
-        sensitivity: f64,
         epsilon: f64,
     ) -> PyResult<u64> {
         let utilities = utilities.to_vec().unwrap();
         let index: u64 = mechanisms::exponential_mechanism_weighted_index(
             utilities,
-            sensitivity,
             epsilon,
         );
         Ok(index)
@@ -87,13 +83,11 @@ fn backend(_py: Python, m: &PyModule) -> PyResult<()> {
     fn py_exponential_mechanism_gumbel_trick<'a>(
         py: Python<'a>,
         utilities: &'a PyArray1<f64>,
-        sensitivity: f64,
         epsilon: f64,
     ) -> PyResult<u64> {
         let utilities = utilities.to_vec().unwrap();
         let index: u64 = mechanisms::exponential_mechanism_gumbel_trick(
             utilities,
-            sensitivity,
             epsilon,
         );
         Ok(index)
@@ -104,13 +98,11 @@ fn backend(_py: Python, m: &PyModule) -> PyResult<()> {
     fn py_exponential_mechanism_sample_and_flip<'a>(
         py: Python<'a>,
         utilities: &'a PyArray1<f64>,
-        sensitivity: f64,
         epsilon: f64,
     ) -> PyResult<u64> {
         let utilities = utilities.to_vec().unwrap();
         let index: u64 = mechanisms::exponential_mechanism_sample_and_flip(
             utilities,
-            sensitivity,
             epsilon,
         );
         Ok(index)
@@ -121,13 +113,11 @@ fn backend(_py: Python, m: &PyModule) -> PyResult<()> {
     fn py_permute_and_flip_mechanism<'a>(
         py: Python<'a>,
         utilities: &'a PyArray1<f64>,
-        sensitivity: f64,
         epsilon: f64,
     ) -> PyResult<u64> {
         let utilities = utilities.to_vec().unwrap();
         let index: u64 = mechanisms::permute_and_flip_mechanism(
             utilities,
-            sensitivity,
             epsilon,
         );
         Ok(index)


### PR DESCRIPTION
Some of the literature describes all release mechanisms as if the
sensitivity of the underlying query is 1.0.  They then state that
these mechanisms privide epsilon * sensitivity - DP.  This has
the advantage of simplifiying the delicate and expensive arbitrary-
precision floating-point computations in the rust code.

We can mimic this approach to describing DP release mechanisms
by computing an "effective epsilon" which we compute as a function
of both the user-requested "true epsilon" and the sensitivity of the 
query function.  This effective epsilon is the value required for a
release mechanism that "thinks" it is working on a function with
sensitivity one introduce enough noise so that we get the desired level
of privacy for a query function with a different sensitivity.

As a part of this, I also modified the class strucutre a little bit.
Because the GeometricMechanism operates on integer-valued data and
adds integer-valued noise, we don't need to adjust the sensitivity
to account for floating-point to fixed-point conversion errors like
we do for the LaplaceMechanism.  As such, it made sense to change
the parent class of GemetricMechanism to the base ReleaseMechanism
class instead of LaplaceMechanism.  This simplified the constructor
for GeometricMechanism now that we're doing the effective epsilon
trick.