### PR TITLE
Sparse queries

### DIFF
--- a/relm/histogram.py
+++ b/relm/histogram.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import scipy.sparse as sps
 
 
 class Histogram:
@@ -81,8 +82,10 @@ class Histogram:
                 idxs = idxs[:, None] + new_idxs[None, :]
                 idxs = idxs.flatten()
 
-        vec = np.zeros(self.size)
-        vec[idxs] = 1
+        rows = np.zeros_like(idxs)
+        vals = np.ones_like(idxs)
+
+        vec = sps.csr_matrix((vals, (rows, idxs)), shape=(1, self.size))
         return vec
 
     def get_db(self):
@@ -90,6 +93,6 @@ class Histogram:
         Returns the database in histogram format.
         """
 
-        db = np.zeros(self.size)
+        db = np.zeros(self.size, dtype=np.uint64)
         db[self.idxs] = self.vals
         return db

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 import scipy.stats
 import pytest
 from relm.mechanisms import (
@@ -277,3 +278,32 @@ def test_SmallDB():
 
     with pytest.raises(ValueError):
         _ = SmallDB(epsilon, data, 1.1)
+
+
+def test_SmallDB_sparse():
+
+    size = 1000
+    data = np.random.randint(0, 10, size)
+    queries = np.vstack([np.random.randint(0, 2, size) for _ in range(3)])
+    queries = scipy.sparse.csr_matrix(queries)
+
+    epsilon = 1
+    alpha = 0.1
+    beta = 0.0001
+    errors = []
+
+    for _ in range(10):
+        mechanism = SmallDB(epsilon, data, alpha)
+        db = mechanism.release(queries)
+        errors.append(
+            abs(queries.dot(data) / data.sum() - queries.dot(db) / db.sum()).max()
+        )
+
+    errors = np.array(errors)
+
+    x = np.log(len(data)) * np.log(queries.shape[0]) / (alpha ** 2) + np.log(1 / beta)
+    error_bound = alpha + 2 * x / (epsilon * data.sum())
+
+    assert (errors < error_bound).all()
+    assert len(db) == size
+    assert db.sum() == int(queries.shape[0] / (alpha ** 2)) + 1


### PR DESCRIPTION
This PR changes `Histogram` to return queries as sparse matrices, and enables `SmallDB` to handle both sparse and dense query matrices.

WIth this change, I can run all the crisper queries (with an epsilon of 4) in 13s and using only ~0.7Gb of memory for the query matrices. Before this, the dense query matrices would have required 7TB of memory!